### PR TITLE
fix container name of dowload client

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3'
 services:
   download:
-    image: databus-download-min:latest
+    image: dbpedia/minimal-download-client:latest
     environment:
       COLLECTION_URI: https://databus.dbpedia.org/kurzum/collections/agro
       TARGET_DIR: /root/data


### PR DESCRIPTION
Fixed the container name from databus-download-min:latest (no longer available in docker hub) to dbpedia/minimal-download-client:latest (https://hub.docker.com/r/dbpedia/minimal-download-client) 